### PR TITLE
Reduce lib size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 export default function debounceRender(ComponentToDebounce, ...debounceArgs) {
     return class DebouncedContainer extends Component {


### PR DESCRIPTION
When you import someting from lodash like this 

```import { debounce } from 'lodash'``` 

tree-shaking doesn't work, so your final bundle includes all lodash functions.

My pull request resolves this issue