### PR TITLE
Add support for hoisting non-react statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Olivier Scherrer <pode.fr@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "hoist-non-react-statics": "^3.3.2",
     "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import debounce from 'lodash/debounce';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
-export default function debounceRender(ComponentToDebounce, ...debounceArgs) {
-    return class DebouncedContainer extends Component {
+function debounceRender(ComponentToDebounce, ...debounceArgs) {
+    class DebouncedContainer extends Component {
         updateDebounced = debounce(this.forceUpdate, ...debounceArgs);
 
         shouldComponentUpdate() {
@@ -18,4 +19,7 @@ export default function debounceRender(ComponentToDebounce, ...debounceArgs) {
             return <ComponentToDebounce {...this.props} />;
         }
     }
+    return hoistNonReactStatics(DebouncedContainer, ComponentToDebounce);
 };
+
+export default debounceRender;


### PR DESCRIPTION
First of all - not sure if hoisting non-react statics is of any interest to be supported as part of this library, but wanted to share my solution for non-react static values not being hoisted in the returned component. Just in case someone else can benefit from it.

Issue became evident as I was using `react-navigation` and `react-debounce-render` at the same time. The latter would make the former not work since `react-navigation` `navigationOptions` are passed as static objects on a per-screen basis. Hoisting the non-react statics solves that.