### PR TITLE
fix lodash.debounce import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import debounce from 'lodash/debounce';
+import debounce from 'lodash.debounce';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 function debounceRender(ComponentToDebounce, ...debounceArgs) {


### PR DESCRIPTION
Currently this module fails due to being unable to locate `lodash/debounce` unless the consumer has `lodash` installed elsewhere. Tests were passing due to a variety of the build tools from create-react-app installing `lodash`. This is just an update to the import so that this is using the `lodash.debounce` library that it actually depends on.

Tested by building + packing + installing in the e2e folder locally, as well as by running the `npm test` command.