### PR TITLE
Add lodash types to dependencies

### DIFF
--- a/packages/react-debounce-render/package.json
+++ b/packages/react-debounce-render/package.json
@@ -38,6 +38,9 @@
   "peerDependencies": {
     "react": "^17.0.2"
   },
+  "optionalDependencies": {
+    "@types/lodash": "^4.14.184"
+  },
   "devDependencies": {
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/lodash.debounce": "^4.0.6",


### PR DESCRIPTION
Without listing the lodash types as a dependency, you get an error like this:

```
../../.yarn/__virtual__/react-debounce-render-virtual-213d9d5692/0/cache/react-debounce-render-npm-8.0.2-d6a1a3772f-a97119badb.zip/node_modules/react-debounce-render/dist/index.d.ts:2:34 - error TS2307: Cannot find module 'lodash' or its corresponding type declarations.

2 import { DebounceSettings } from 'lodash';
```

Type dependencies that will be needed by the end user should go in optionalDependencies rather than devDependencies.