### PR TITLE
Allow externally defined shouldComponentUpdate

### DIFF
--- a/packages/react-debounce-render/src/index.tsx
+++ b/packages/react-debounce-render/src/index.tsx
@@ -4,13 +4,17 @@ import { DebounceSettings } from 'lodash';
 
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
-function debounceRender<T>(ComponentToDebounce: ComponentType<T>, wait?: number, debounceArgs?: DebounceSettings): ComponentType<T> {
+function debounceRender<T>(ComponentToDebounce: ComponentType<T>, wait?: number, debounceArgs?: DebounceSettings, forceUpdateCondition?: (nextProps: T, nextState: S) => boolean): ComponentType<T> {
     class DebouncedContainer extends Component<T> {
         public static readonly displayName = `debounceRender(${ ComponentToDebounce.displayName || ComponentToDebounce.name || 'Component' })`;
         updateDebounced = _debounce(this.forceUpdate, wait, debounceArgs);
 
         shouldComponentUpdate() {
-            this.updateDebounced();
+            if (typeof forceUpdateCondition === 'function' && forceUpdateCondition(nextProps, nextState)) {
+                this.updateDebounced.flush();
+            } else {
+                this.updateDebounced();
+            }
             return false;
         }
 

--- a/packages/react-debounce-render/src/index.tsx
+++ b/packages/react-debounce-render/src/index.tsx
@@ -10,10 +10,9 @@ function debounceRender<T>(ComponentToDebounce: ComponentType<T>, wait?: number,
         updateDebounced = _debounce(this.forceUpdate, wait, debounceArgs);
 
         shouldComponentUpdate() {
+            this.updateDebounced();
             if (typeof forceUpdateCondition === 'function' && forceUpdateCondition(this.props, nextProps, this.state, nextState)) {
                 this.updateDebounced.flush();
-            } else {
-                this.updateDebounced();
             }
             return false;
         }

--- a/packages/react-debounce-render/src/index.tsx
+++ b/packages/react-debounce-render/src/index.tsx
@@ -4,13 +4,13 @@ import { DebounceSettings } from 'lodash';
 
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
-function debounceRender<T>(ComponentToDebounce: ComponentType<T>, wait?: number, debounceArgs?: DebounceSettings, forceUpdateCondition?: (nextProps: T, nextState: S) => boolean): ComponentType<T> {
+function debounceRender<T>(ComponentToDebounce: ComponentType<T>, wait?: number, debounceArgs?: DebounceSettings, forceUpdateCondition?: (prevProps: T, nextProps: T, prevState: S, nextState: S) => boolean): ComponentType<T> {
     class DebouncedContainer extends Component<T> {
         public static readonly displayName = `debounceRender(${ ComponentToDebounce.displayName || ComponentToDebounce.name || 'Component' })`;
         updateDebounced = _debounce(this.forceUpdate, wait, debounceArgs);
 
         shouldComponentUpdate() {
-            if (typeof forceUpdateCondition === 'function' && forceUpdateCondition(nextProps, nextState)) {
+            if (typeof forceUpdateCondition === 'function' && forceUpdateCondition(this.props, nextProps, this.state, nextState)) {
                 this.updateDebounced.flush();
             } else {
                 this.updateDebounced();


### PR DESCRIPTION
This commit allows the user to externally control immediate updates with a callback similar to `shouldComponentUpdate`. When that returns true, we can flush the debounced update, and immediately re-render.